### PR TITLE
Migrate frontend UI to shadcn components

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,8 +10,6 @@
     },
     "dependencies": {
         "@colyseus/schema": "^3.0.60",
-        "@emotion/styled": "^11.13.0",
-        "@mui/material": "^6.0.1",
         "@tweenjs/tween.js": "^25.0.0",
         "@types/cannon": "^0.1.12",
         "@types/cli-progress": "^3.11.6",

--- a/frontend/src/components/AssetLoader.tsx
+++ b/frontend/src/components/AssetLoader.tsx
@@ -1,7 +1,8 @@
-import { ReactNode, useEffect } from "react";
+import { useEffect } from "react";
 import { useAssetStore } from "../store/useAssetLoader";
-import { LinearProgress } from "@mui/material";
 import { assetsList } from "@/config/assetsList";
+import { Progress } from "@/components/ui/progress";
+import { cn } from "@/components/ui/utils";
 
 export default function AssetLoader() {
     const { progress, skipAssets, loadMeshes } = useAssetStore();
@@ -18,16 +19,12 @@ export default function AssetLoader() {
     }, []);
 
     return (
-        <LinearProgress
-            style={{
-                width: "52.13vh",
-                marginTop: 10,
-                opacity: 0.2 * +(progress <= 1),
-                transition: "opacity 1s ease-out",
-            }}
-            variant="determinate"
-            color="inherit"
+        <Progress
             value={Math.min(progress, 1) * 100}
+            className={cn(
+                "mt-2 w-[52.13vh] transition-opacity duration-1000",
+                progress <= 1 ? "opacity-20" : "opacity-0"
+            )}
         />
     );
 }

--- a/frontend/src/components/Play.tsx
+++ b/frontend/src/components/Play.tsx
@@ -2,6 +2,7 @@ import { Socket } from "socket.io-client";
 import { useStyles } from "../hooks/useStyles";
 import { usePlayScreen } from "../viewmodels";
 import { KartClient } from "@/types/KartClient";
+import { Button } from "@/components/ui/button";
 
 export function Play({
     client,
@@ -54,15 +55,15 @@ export function Play({
                     <table id="scoreboard">
                         <tbody></tbody>
                     </table>
-                    <button
+                    <Button
                         style={{
                             pointerEvents: "all",
                             marginBottom: 10,
                         }}
-                        className="r scoreboard_finish"
+                        className="scoreboard_finish"
                     >
                         Disconnect
-                    </button>
+                    </Button>
                 </center>
             </main>
 
@@ -74,12 +75,15 @@ export function Play({
                     <h5>Game Paused</h5>
                     <p>but the server, keeps playing</p>
                     <center>
-                        <button className="r" id="resume">
+                        <Button id="resume" className="mt-4 min-w-[10rem]">
                             Resume
-                        </button>
-                        <button className="r" id="disconnect">
+                        </Button>
+                        <Button
+                            id="disconnect"
+                            className="mt-4 min-w-[10rem]"
+                        >
                             Disconnect
-                        </button>
+                        </Button>
                     </center>
                 </div>
             </main>

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -1,8 +1,4 @@
 import { useSettingsScreen } from "../viewmodels/useSettingsScreen";
-import Slider from "@mui/material/Slider";
-import Select from "@mui/material/Select";
-import { MenuItem, Input, Switch } from "@mui/material";
-import { ToggleButton, ToggleButtonGroup } from "@mui/material";
 import { AiFillSound } from "react-icons/ai";
 import { IoIosSettings } from "react-icons/io";
 import { PiGraphicsCardFill } from "react-icons/pi";
@@ -11,6 +7,12 @@ import { Listed } from "../components/Listed";
 import { Condition } from "../components/Condition";
 import { CSSProperties } from "react";
 import { BsFillQuestionCircleFill } from "react-icons/bs";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select, SelectOption } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Slider } from "@/components/ui/slider";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 export function Settings({
     goBack,
     style,
@@ -52,50 +54,46 @@ export function Settings({
     return (
         <main style={style}>
             <h1 style={{ fontSize: "6.0vh" }}>Settings</h1>
-            <center>
-                <ToggleButtonGroup
-                    color="primary"
+            <div className="flex justify-center">
+                <ToggleGroup
                     value={nav}
-                    exclusive
-                    onChange={(_, i) => {
-                        if (i === null) return;
-                        setNav(i as number);
-                    }}
+                    onValueChange={(value) => setNav(Number(value))}
+                    className="flex gap-4"
                 >
-                    <ToggleButton
+                    <ToggleGroupItem
                         data-tooltip-id="t"
                         data-tooltip-content={"Game Settings"}
                         value={0}
-                        className="r mini"
+                        className="h-12 w-12 rounded-md border border-neutral-700 bg-neutral-950 hover:border-neutral-500 hover:bg-neutral-900"
                     >
                         <IoIosSettings size={30} color="white" />
-                    </ToggleButton>
-                    <ToggleButton
+                    </ToggleGroupItem>
+                    <ToggleGroupItem
                         data-tooltip-id="t"
                         data-tooltip-content={"Audio Settings"}
                         value={1}
-                        className="r mini"
+                        className="h-12 w-12 rounded-md border border-neutral-700 bg-neutral-950 hover:border-neutral-500 hover:bg-neutral-900"
                     >
                         <AiFillSound size={30} color="white" />
-                    </ToggleButton>
-                    <ToggleButton
+                    </ToggleGroupItem>
+                    <ToggleGroupItem
                         data-tooltip-id="t"
                         data-tooltip-content={"Graphics Settings"}
                         value={2}
-                        className="r mini"
+                        className="h-12 w-12 rounded-md border border-neutral-700 bg-neutral-950 hover:border-neutral-500 hover:bg-neutral-900"
                     >
                         <PiGraphicsCardFill size={30} color="white" />
-                    </ToggleButton>
-                    <ToggleButton
+                    </ToggleGroupItem>
+                    <ToggleGroupItem
                         data-tooltip-id="t"
                         data-tooltip-content={"Hide/Show Elements"}
                         value={3}
-                        className="r mini"
+                        className="h-12 w-12 rounded-md border border-neutral-700 bg-neutral-950 hover:border-neutral-500 hover:bg-neutral-900"
                     >
                         <IoMdEye size={30} color="white" />
-                    </ToggleButton>
-                </ToggleButtonGroup>
-            </center>
+                    </ToggleGroupItem>
+                </ToggleGroup>
+            </div>
             <div style={{ minHeight: "45.7vh" }}>
                 <table id="settings">
                     <tbody>
@@ -107,11 +105,7 @@ export function Settings({
                                         <td>Player Name</td>
                                         <td>
                                             <Input
-                                                style={{
-                                                    display: "inline-block",
-                                                    width: "26.06vh",
-                                                }}
-                                                size="small"
+                                                className="inline-block w-[26.06vh]"
                                                 data-tooltip-id="t"
                                                 data-tooltip-content={
                                                     "Player Name"
@@ -134,30 +128,22 @@ export function Settings({
                                         <td>
                                             <Select
                                                 key={"useArrow"}
-                                                color="info"
-                                                style={{
-                                                    color: "white",
-                                                    width: "22.419vh",
-                                                    height: "4.17vh",
-                                                    textAlign: "center",
-                                                    border: "1px solid #444",
-                                                }}
+                                                className="h-10 w-[22.419vh] border border-neutral-700 bg-neutral-950 text-center text-white"
                                                 onChange={(event) => {
                                                     set({
                                                         useArrow:
-                                                            (event.target
-                                                                .value as number) ===
-                                                            1,
+                                                            event.currentTarget
+                                                                .value === "1",
                                                     });
                                                 }}
-                                                value={+useArrow}
+                                                value={String(+useArrow)}
                                             >
-                                                <MenuItem value={0}>
+                                                <SelectOption value="0">
                                                     Circle
-                                                </MenuItem>
-                                                <MenuItem value={1}>
+                                                </SelectOption>
+                                                <SelectOption value="1">
                                                     Arrow
-                                                </MenuItem>
+                                                </SelectOption>
                                             </Select>
                                         </td>
                                     </tr>
@@ -171,13 +157,10 @@ export function Settings({
                                                 min={0}
                                                 step={0.01}
                                                 max={1}
-                                                style={{ width: 150 }}
+                                                className="w-40"
                                                 value={fovChange}
-                                                onChange={(_, value) =>
-                                                    set({
-                                                        fovChange:
-                                                            value as number,
-                                                    })
+                                                onValueChange={(value) =>
+                                                    set({ fovChange: value })
                                                 }
                                             />
                                             <p
@@ -201,7 +184,7 @@ export function Settings({
                                             <Switch
                                                 key={"displayVelocity"}
                                                 checked={displayVelocity}
-                                                onChange={(_, value) =>
+                                                onCheckedChange={(value) =>
                                                     set({
                                                         displayVelocity: value,
                                                     })
@@ -221,13 +204,10 @@ export function Settings({
                                                 min={0}
                                                 step={0.01}
                                                 max={1}
-                                                style={{ width: "15.64" }}
+                                                className="w-[15.64vh]"
                                                 value={masterVolume}
-                                                onChange={(_, value) => {
-                                                    set({
-                                                        masterVolume:
-                                                            value as number,
-                                                    });
+                                                onValueChange={(value) => {
+                                                    set({ masterVolume: value });
                                                 }}
                                             />
                                             <p
@@ -249,13 +229,10 @@ export function Settings({
                                                 min={0}
                                                 step={0.01}
                                                 max={1}
-                                                style={{ width: "15.64" }}
+                                                className="w-[15.64vh]"
                                                 value={musicVolume}
-                                                onChange={(_, value) => {
-                                                    set({
-                                                        musicVolume:
-                                                            value as number,
-                                                    });
+                                                onValueChange={(value) => {
+                                                    set({ musicVolume: value });
                                                 }}
                                             />
                                             <p
@@ -277,13 +254,10 @@ export function Settings({
                                                 min={0}
                                                 step={0.01}
                                                 max={1}
-                                                style={{ width: "15.64" }}
+                                                className="w-[15.64vh]"
                                                 value={sfxVolume}
-                                                onChange={(_, value) => {
-                                                    set({
-                                                        sfxVolume:
-                                                            value as number,
-                                                    });
+                                                onValueChange={(value) => {
+                                                    set({ sfxVolume: value });
                                                 }}
                                             />
                                             <p
@@ -307,7 +281,7 @@ export function Settings({
                                             <Switch
                                                 key={"displayAudio"}
                                                 checked={displayAudio}
-                                                onChange={(_, value) =>
+                                                onCheckedChange={(value) =>
                                                     set({ displayAudio: value })
                                                 }
                                             />
@@ -332,12 +306,10 @@ export function Settings({
                                                 min={15}
                                                 step={5}
                                                 max={120}
-                                                style={{ width: "15.64" }}
+                                                className="w-[15.64vh]"
                                                 value={fps}
-                                                onChange={(_, value) => {
-                                                    set({
-                                                        fps: value as number,
-                                                    });
+                                                onValueChange={(value) => {
+                                                    set({ fps: value });
                                                 }}
                                             />
                                             <p
@@ -363,7 +335,7 @@ export function Settings({
                                             <Switch
                                                 key={"useVsync"}
                                                 checked={useVsync}
-                                                onChange={(_, value) =>
+                                                onCheckedChange={(value) =>
                                                     set({ useVsync: value })
                                                 }
                                             />
@@ -386,7 +358,7 @@ export function Settings({
                                             <Switch
                                                 key={"useSTATS"}
                                                 checked={useSTATS}
-                                                onChange={(_, value) =>
+                                                onCheckedChange={(value) =>
                                                     set({ useSTATS: value })
                                                 }
                                             />
@@ -404,7 +376,7 @@ export function Settings({
                                             <Switch
                                                 key={"useBloom"}
                                                 checked={useBloom}
-                                                onChange={(_, value) =>
+                                                onCheckedChange={(value) =>
                                                     set({ useBloom: value })
                                                 }
                                             />
@@ -420,13 +392,10 @@ export function Settings({
                                                 min={0}
                                                 step={5}
                                                 max={100}
-                                                style={{ width: "15.64" }}
+                                                className="w-[15.64vh]"
                                                 value={motionBlur}
-                                                onChange={(_, value) => {
-                                                    set({
-                                                        motionBlur:
-                                                            value as number,
-                                                    });
+                                                onValueChange={(value) => {
+                                                    set({ motionBlur: value });
                                                 }}
                                             />
                                             <p
@@ -452,7 +421,7 @@ export function Settings({
                                             <Switch
                                                 key={"Antialiasing"}
                                                 checked={Antialiasing}
-                                                onChange={(_, value) =>
+                                                onCheckedChange={(value) =>
                                                     set({ Antialiasing: value })
                                                 }
                                             />
@@ -469,7 +438,7 @@ export function Settings({
                                         >
                                             <Switch
                                                 checked={renderColliders}
-                                                onChange={(_, value) =>
+                                                onCheckedChange={(value) =>
                                                     set({
                                                         renderColliders: value,
                                                     })
@@ -491,7 +460,7 @@ export function Settings({
                                             <Switch
                                                 key={"displaySun"}
                                                 checked={displaySun}
-                                                onChange={(_, value) =>
+                                                onCheckedChange={(value) =>
                                                     set({ displaySun: value })
                                                 }
                                             />
@@ -509,7 +478,7 @@ export function Settings({
                                             <Switch
                                                 key={"displayStars"}
                                                 checked={displayStars}
-                                                onChange={(_, value) =>
+                                                onCheckedChange={(value) =>
                                                     set({ displayStars: value })
                                                 }
                                             />
@@ -527,7 +496,7 @@ export function Settings({
                                             <Switch
                                                 key={"displayFences"}
                                                 checked={displayFences}
-                                                onChange={(_, value) =>
+                                                onCheckedChange={(value) =>
                                                     set({
                                                         displayFences: value,
                                                     })
@@ -547,7 +516,7 @@ export function Settings({
                                             <Switch
                                                 key={"displayPillars"}
                                                 checked={displayPillars}
-                                                onChange={(_, value) =>
+                                                onCheckedChange={(value) =>
                                                     set({
                                                         displayPillars: value,
                                                     })
@@ -567,7 +536,7 @@ export function Settings({
                                             <Switch
                                                 key={"displayWater"}
                                                 checked={displayWater}
-                                                onChange={(_, value) =>
+                                                onCheckedChange={(value) =>
                                                     set({ displayWater: value })
                                                 }
                                             />
@@ -585,41 +554,41 @@ export function Settings({
             <Condition
                 conditions={goBack === undefined}
                 onTrue={
-                    <button className="r" id={backButtonID}>
+                    <Button id={backButtonID} className="mt-6 min-w-[8rem]">
                         Back
-                    </button>
+                    </Button>
                 }
                 onFalse={
-                    <button className="r" onClick={() => goBack!()}>
+                    <Button className="mt-6 min-w-[8rem]" onClick={() => goBack!()}>
                         Back
-                    </button>
+                    </Button>
                 }
             />
 
-            <button
-                className="r"
+            <Button
+                className="mt-4"
                 data-tooltip-id="t"
                 data-tooltip-content={"Load From Cookies"}
                 onClick={() => loadFromCookies(true)}
             >
                 Load
-            </button>
-            <button
-                className="r"
+            </Button>
+            <Button
+                className="mt-4 ml-4"
                 data-tooltip-id="t"
                 data-tooltip-content={"Save to Cookies"}
                 onClick={() => saveToCookies(true)}
             >
                 Save
-            </button>
-            <button
-                className="r"
+            </Button>
+            <Button
+                className="mt-4 ml-4"
                 data-tooltip-id="t"
                 data-tooltip-content={"Reset to defaults"}
                 onClick={() => reset()}
             >
                 Reset
-            </button>
+            </Button>
         </main>
     );
 }

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import { cn } from "./utils";
+
+type ButtonVariant = "default" | "secondary" | "outline" | "ghost";
+type ButtonSize = "default" | "sm" | "lg" | "icon";
+
+const variantStyles: Record<ButtonVariant, string> = {
+    default:
+        "bg-neutral-900 text-white border border-neutral-700 hover:bg-neutral-800 hover:border-neutral-600",
+    secondary:
+        "bg-neutral-800 text-neutral-100 border border-neutral-700 hover:bg-neutral-700",
+    outline:
+        "border border-neutral-700 text-neutral-100 hover:bg-neutral-900",
+    ghost: "text-neutral-100 hover:bg-neutral-900",
+};
+
+const sizeStyles: Record<ButtonSize, string> = {
+    default: "h-10 px-6 py-2 text-base",
+    sm: "h-8 px-3 text-sm",
+    lg: "h-12 px-8 text-lg",
+    icon: "h-10 w-10 p-0",
+};
+
+export interface ButtonProps
+    extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    variant?: ButtonVariant;
+    size?: ButtonSize;
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+    ({ className, variant = "default", size = "default", type = "button", ...props }, ref) => {
+        return (
+            <button
+                ref={ref}
+                type={type}
+                className={cn(
+                    "inline-flex items-center justify-center gap-2 rounded-md font-medium transition-transform duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-950 disabled:cursor-not-allowed disabled:opacity-50",
+                    variantStyles[variant],
+                    sizeStyles[size],
+                    className
+                )}
+                {...props}
+            />
+        );
+    }
+);
+
+Button.displayName = "Button";

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+import { cn } from "./utils";
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+    ({ className, type = "text", ...props }, ref) => {
+        return (
+            <input
+                ref={ref}
+                type={type}
+                className={cn(
+                    "flex h-10 w-full rounded-md border border-neutral-700 bg-neutral-950 px-4 py-2 text-base text-neutral-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-950 disabled:cursor-not-allowed disabled:opacity-50",
+                    className
+                )}
+                {...props}
+            />
+        );
+    }
+);
+
+Input.displayName = "Input";

--- a/frontend/src/components/ui/progress.tsx
+++ b/frontend/src/components/ui/progress.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import { cn } from "./utils";
+
+export interface ProgressProps
+    extends React.HTMLAttributes<HTMLDivElement> {
+    value?: number;
+}
+
+export function Progress({ value = 0, className, ...props }: ProgressProps) {
+    return (
+        <div
+            className={cn(
+                "relative h-2 w-full overflow-hidden rounded-full bg-neutral-900",
+                className
+            )}
+            role="progressbar"
+            aria-valuenow={value}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            {...props}
+        >
+            <div
+                className="h-full w-full origin-left scale-x-[var(--progress)] transform bg-emerald-400 transition-transform duration-300"
+                style={{
+                    // clamp value between 0 and 100
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    ...(value !== undefined
+                        ? { "--progress": `${Math.min(Math.max(value, 0), 100) / 100}` }
+                        : { "--progress": 0 }),
+                } as React.CSSProperties}
+            />
+        </div>
+    );
+}

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import { cn } from "./utils";
+
+export interface SelectProps
+    extends React.SelectHTMLAttributes<HTMLSelectElement> {}
+
+export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+    ({ className, children, ...props }, ref) => {
+        return (
+            <select
+                ref={ref}
+                className={cn(
+                    "flex h-10 w-full appearance-none rounded-md border border-neutral-700 bg-neutral-950 px-4 pr-10 text-left text-base text-neutral-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-950 disabled:cursor-not-allowed disabled:opacity-50",
+                    className
+                )}
+                {...props}
+            >
+                {children}
+            </select>
+        );
+    }
+);
+
+Select.displayName = "Select";
+
+export const SelectOption = (
+    props: React.OptionHTMLAttributes<HTMLOptionElement>
+) => {
+    return <option {...props} />;
+};

--- a/frontend/src/components/ui/slider.tsx
+++ b/frontend/src/components/ui/slider.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { cn } from "./utils";
+
+export interface SliderProps
+    extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "onChange"> {
+    value: number;
+    onValueChange?: (value: number) => void;
+}
+
+export const Slider = React.forwardRef<HTMLInputElement, SliderProps>(
+    ({ className, value, onValueChange, min = 0, max = 100, step = 1, ...props }, ref) => {
+        return (
+            <input
+                ref={ref}
+                type="range"
+                value={value}
+                min={min}
+                max={max}
+                step={step}
+                onChange={(event) => onValueChange?.(event.currentTarget.valueAsNumber)}
+                className={cn(
+                    "h-2 w-full cursor-pointer appearance-none rounded-full bg-neutral-800 accent-emerald-400",
+                    className
+                )}
+                {...props}
+            />
+        );
+    }
+);
+
+Slider.displayName = "Slider";

--- a/frontend/src/components/ui/switch.tsx
+++ b/frontend/src/components/ui/switch.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { cn } from "./utils";
+
+export interface SwitchProps
+    extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "onChange"> {
+    checked?: boolean;
+    onCheckedChange?: (checked: boolean) => void;
+}
+
+export const Switch = React.forwardRef<HTMLButtonElement, SwitchProps>(
+    ({ className, checked = false, onCheckedChange, ...props }, ref) => {
+        return (
+            <button
+                ref={ref}
+                type="button"
+                role="switch"
+                aria-checked={checked}
+                onClick={() => onCheckedChange?.(!checked)}
+                className={cn(
+                    "relative inline-flex h-6 w-12 items-center rounded-full border border-neutral-700 bg-neutral-900 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-500 focus-visible:ring-offset-2 focus-visible:ring-offset-neutral-950",
+                    checked ? "bg-emerald-500/20 border-emerald-500" : "bg-neutral-900",
+                    className
+                )}
+                {...props}
+            >
+                <span
+                    className={cn(
+                        "inline-block h-5 w-5 translate-x-1 rounded-full bg-neutral-100 transition-transform",
+                        checked ? "translate-x-6 bg-emerald-400" : "translate-x-1"
+                    )}
+                />
+            </button>
+        );
+    }
+);
+
+Switch.displayName = "Switch";

--- a/frontend/src/components/ui/toggle-group.tsx
+++ b/frontend/src/components/ui/toggle-group.tsx
@@ -1,0 +1,64 @@
+import * as React from "react";
+import { cn } from "./utils";
+
+type ToggleValue = string | number;
+
+type ToggleGroupContextValue = {
+    value: ToggleValue;
+    onValueChange?: (value: ToggleValue) => void;
+};
+
+const ToggleGroupContext = React.createContext<
+    ToggleGroupContextValue | undefined
+>(undefined);
+
+type ToggleGroupProps = {
+    value: ToggleValue;
+    onValueChange?: (value: ToggleValue) => void;
+    className?: string;
+    children: React.ReactNode;
+};
+
+export function ToggleGroup({
+    value,
+    onValueChange,
+    className,
+    children,
+}: ToggleGroupProps) {
+    return (
+        <ToggleGroupContext.Provider value={{ value, onValueChange }}>
+            <div className={cn("inline-flex gap-3", className)}>{children}</div>
+        </ToggleGroupContext.Provider>
+    );
+}
+
+type ToggleGroupItemProps = {
+    value: ToggleValue;
+    children: React.ReactNode;
+    className?: string;
+};
+
+export function ToggleGroupItem({ value, children, className }: ToggleGroupItemProps) {
+    const context = React.useContext(ToggleGroupContext);
+
+    if (!context) {
+        throw new Error("ToggleGroupItem must be used within ToggleGroup");
+    }
+
+    const isActive = context.value === value;
+
+    return (
+        <button
+            type="button"
+            onClick={() => context.onValueChange?.(value)}
+            className={cn(
+                "inline-flex h-10 min-w-[2.5rem] items-center justify-center rounded-md border border-neutral-700 bg-neutral-950 px-4 text-base text-neutral-100 transition-all hover:border-neutral-500 hover:bg-neutral-900",
+                isActive && "border-neutral-100 bg-neutral-800",
+                className
+            )}
+            data-state={isActive ? "on" : "off"}
+        >
+            {children}
+        </button>
+    );
+}

--- a/frontend/src/components/ui/utils.tsx
+++ b/frontend/src/components/ui/utils.tsx
@@ -1,0 +1,5 @@
+export function cn(
+    ...inputs: Array<string | false | null | undefined>
+): string {
+    return inputs.filter(Boolean).join(" ");
+}

--- a/frontend/src/lib/AudioContainer/index.tsx
+++ b/frontend/src/lib/AudioContainer/index.tsx
@@ -1,5 +1,5 @@
 import { useSettingsStore } from "@/store/useSettingsStore";
-import { Button } from "@mui/material";
+import { Button } from "@/components/ui/button";
 import {
     createRef,
     Dispatch,
@@ -120,11 +120,7 @@ const AudioHTML = forwardRef<AudioRef, {}>((_, ref) => {
                                     setPlaying(false);
                                 }
                             }}
-                            style={{
-                                marginBlock: "auto",
-                                marginRight: 20,
-                                cursor: "pointer",
-                            }}
+                            className="my-auto mr-5 h-12 w-12 rounded-full border border-neutral-700 bg-neutral-900 p-0 hover:bg-neutral-800"
                         >
                             {[FaPlay, FaPause][+playing]({
                                 size: 18,

--- a/frontend/src/pages/create.tsx
+++ b/frontend/src/pages/create.tsx
@@ -1,7 +1,9 @@
 import AssetLoader from "@/components/AssetLoader";
 import { AudioContainer } from "@/lib/AudioContainer";
 import { useCreateScreen } from "@/viewmodels/useCreateScreen";
-import { ToggleButton, ToggleButtonGroup } from "@mui/material";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 
 export default function () {
     const {
@@ -22,57 +24,52 @@ export default function () {
             </header>
             <AudioContainer />
 
-            <main style={{ display: "flex", gap: 100 }}>
+            <main className="flex gap-24">
                 <div>
-                    <h1 style={{ fontSize: "4.17vh" }}>Map Selection</h1>
-                    <center>
-                        <ToggleButtonGroup
-                            color="primary"
+                    <h1 className="text-[4.17vh]">Map Selection</h1>
+                    <div className="flex justify-center">
+                        <ToggleGroup
                             value={roomMap}
-                            onChange={(_, i) => {
-                                if (i === null) return;
-                                setRoomMap(i as number);
-                            }}
-                            exclusive
+                            onValueChange={(value) => setRoomMap(Number(value))}
+                            className="gap-3"
                         >
-                            <ToggleButton className="r mini" value={0}>
+                            <ToggleGroupItem
+                                value={0}
+                                className="h-12 min-w-[6rem] rounded-md border border-neutral-700 bg-neutral-950 px-6 text-lg text-white hover:border-neutral-500 hover:bg-neutral-900"
+                            >
                                 Horde
-                            </ToggleButton>
-                            <ToggleButton className="r mini" value={1}>
+                            </ToggleGroupItem>
+                            <ToggleGroupItem
+                                value={1}
+                                className="h-12 min-w-[6rem] rounded-md border border-neutral-700 bg-neutral-950 px-6 text-lg text-white hover:border-neutral-500 hover:bg-neutral-900"
+                            >
                                 Hotel
-                            </ToggleButton>
-                        </ToggleButtonGroup>
-                    </center>
+                            </ToggleGroupItem>
+                        </ToggleGroup>
+                    </div>
                     <br />
                     <canvas
                         width={500}
                         height={500}
-                        style={{ width: "36.49vh", height: "36.49vh" }}
+                        className="h-[36.49vh] w-[36.49vh]"
                         ref={roomMapCanvasRef}
                     ></canvas>
                 </div>
                 <div
-                    style={{
-                        display: "block",
-                        marginBlock: "auto",
-                        height: "31.28vh",
-                        width: "0.52vh",
-                        borderRadius: 10,
-                        backgroundColor: "rgba(255,255,255,25%)",
-                    }}
+                    className="my-auto block h-[31.28vh] w-[0.52vh] rounded-[10px] bg-[rgba(255,255,255,0.25)]"
                 ></div>
-                <div style={{ width: "62.5vh", marginBlock: "auto" }}>
-                    <h1 style={{ fontSize: "5.21vh" }}>Create Room</h1>
-                    <input
-                        style={{ marginBottom: 10, width: "100%" }}
+                <div className="my-auto w-[62.5vh]">
+                    <h1 className="text-[5.21vh]">Create Room</h1>
+                    <Input
+                        className="mb-2 w-full"
                         type="text"
                         defaultValue={roomName}
                         placeholder="Room's Name"
                         onChange={(e) => setRoomName(e.currentTarget.value)}
                     />
                     <br />
-                    <input
-                        style={{ width: "100%" }}
+                    <Input
+                        className="w-full"
                         defaultValue={roomPassword}
                         type="password"
                         placeholder="Room's Password"
@@ -83,27 +80,24 @@ export default function () {
                     <center>
                         <br />
                         <div
-                            style={{
-                                display: "flex",
-                                justifyContent: "space-around",
-                            }}
+                            className="flex justify-around"
                         >
-                            <button
-                                className="r"
+                            <Button
+                                className="min-w-[8rem]"
                                 onClick={() => {
                                     router.push("/");
                                 }}
                             >
                                 cancel
-                            </button>
-                            <button
-                                className="r"
+                            </Button>
+                            <Button
+                                className="min-w-[8rem]"
                                 onClick={() => {
                                     createRoom();
                                 }}
                             >
                                 create room
-                            </button>
+                            </Button>
                         </div>
                     </center>
                 </div>

--- a/frontend/src/pages/credits.tsx
+++ b/frontend/src/pages/credits.tsx
@@ -1,6 +1,7 @@
 import AssetLoader from "@/components/AssetLoader";
 import { AudioContainer } from "@/lib/AudioContainer";
 import { useRouter } from "next/router";
+import { Button } from "@/components/ui/button";
 
 export default function () {
     const router = useRouter();
@@ -106,14 +107,14 @@ export default function () {
                 </div>
                 <br />
                 <center>
-                    <button
-                        className="r"
+                    <Button
+                        className="min-w-[8rem]"
                         onClick={() => {
                             goBack();
                         }}
                     >
                         back
-                    </button>
+                    </Button>
                 </center>
             </main>
         </>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -4,7 +4,8 @@ import AssetLoader from "../components/AssetLoader";
 import { FidgetSpinner } from "react-loader-spinner";
 import { BiErrorAlt } from "react-icons/bi";
 import { AudioContainer } from "../lib/AudioContainer";
-import { Button, TextField } from "@mui/material";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { FaLock } from "react-icons/fa";
 import { useRouter } from "next/router";
 import { useRoom } from "@/hooks/useRoom";
@@ -83,10 +84,9 @@ function Index() {
                                 justifyContent: "center",
                             }}
                         >
-                            <TextField
+                            <Input
                                 data-tooltip-id="t"
                                 data-tooltip-content={"Player Name"}
-                                variant="outlined"
                                 placeholder="Enter Player Name"
                                 value={playerName}
                                 onChange={(a) =>
@@ -97,7 +97,10 @@ function Index() {
                         <br />
                         <br />
                         <center>
-                            <Button className="r" onClick={onPlayButton}>
+                            <Button
+                                className="min-w-[10rem]"
+                                onClick={onPlayButton}
+                            >
                                 Play
                             </Button>
                         </center>
@@ -266,38 +269,38 @@ function Index() {
                                     minWidth: "100%",
                                 }}
                             >
-                                <button
+                                <Button
                                     data-tooltip-id="t"
                                     data-tooltip-content={"Reload Rooms"}
-                                    className="r mini"
+                                    className="h-12 min-w-[7rem] px-4 text-sm uppercase"
                                     onClick={() => loadRooms()}
                                 >
                                     reload
-                                </button>
-                                <button
+                                </Button>
+                                <Button
                                     data-tooltip-id="t"
                                     data-tooltip-content={"Create Room"}
-                                    className="r mini"
+                                    className="h-12 min-w-[7rem] px-4 text-sm uppercase"
                                     onClick={() => router.push("/create")}
                                 >
                                     create
-                                </button>
-                                <button
+                                </Button>
+                                <Button
                                     data-tooltip-id="t"
                                     data-tooltip-content={"Credits Page"}
-                                    className="r mini"
+                                    className="h-12 min-w-[7rem] px-4 text-sm uppercase"
                                     onClick={() => router.push("/credits")}
                                 >
                                     credits
-                                </button>
-                                <button
+                                </Button>
+                                <Button
                                     data-tooltip-id="t"
                                     data-tooltip-content={"Settings Page"}
-                                    className="r mini"
+                                    className="h-12 min-w-[7rem] px-4 text-sm uppercase"
                                     onClick={() => router.push("/settings")}
                                 >
                                     settings
-                                </button>
+                                </Button>
                             </div>
                         </div>
                     </main>,

--- a/frontend/src/pages/play/[roomId]/index.tsx
+++ b/frontend/src/pages/play/[roomId]/index.tsx
@@ -9,6 +9,7 @@ import { useRoomScreen } from "@/viewmodels/useRoomScreen";
 import { useRouter } from "next/router";
 import { GoDotFill } from "react-icons/go";
 import { ShaderScripts } from "@/components/ShaderScripts";
+import { Button } from "@/components/ui/button";
 
 export default function () {
     const [room] = useRoom();
@@ -159,16 +160,16 @@ export default function () {
                                                         gap: 10,
                                                     }}
                                                 >
-                                                    <button
-                                                        className="r"
+                                                    <Button
+                                                        className="min-w-[8rem]"
                                                         onClick={() =>
                                                             disconnect()
                                                         }
                                                     >
                                                         Disconnect
-                                                    </button>
-                                                    <button
-                                                        className="r"
+                                                    </Button>
+                                                    <Button
+                                                        className="min-w-[8rem]"
                                                         onClick={() =>
                                                             toggleReady()
                                                         }
@@ -179,7 +180,7 @@ export default function () {
                                                                 "Unready",
                                                             ][+ready]
                                                         }
-                                                    </button>
+                                                    </Button>
                                                 </div>
                                             </div>
                                         </div>

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,3 +1,4 @@
+@import "tailwindcss";
 @import url("https://fonts.googleapis.com/css2?family=Signika:wght@300..700&display=swap");
 @import url("https://fonts.cdnfonts.com/css/new-super-mario-font-u");
 
@@ -32,7 +33,6 @@ main {
 }
 
 body,
-body button.r,
 body input,
 p {
     font-family: "Signika";
@@ -44,28 +44,6 @@ p {
     margin-block: 0px;
 }
 body input,
-body button.r {
-    background-color: #15151500;
-    transition: background-color 0.2s, border 0.2s, scale 0.2s;
-    border: 2px solid #444;
-    font-size: 2.29vh;
-    padding: 1.04vh 2.08vh;
-
-    box-sizing: content-box;
-    cursor: pointer;
-    border-radius: 2px;
-}
-body input:hover,
-body input:focus {
-    outline: 0;
-    border: 2px solid #777;
-}
-body button.r {
-    scale: 0.92;
-    padding: 1.04vh 5.21vh;
-}
-
-body input,
 body input:hover {
     color: white !important;
     outline: 0 !important;
@@ -74,17 +52,6 @@ body input:hover {
 body input:focus {
     border: 0 !important;
 }
-body button.r[aria-pressed="true"],
-body button.r:hover {
-    scale: 1;
-
-    border: 2px solid #151515ff;
-    background-color: #151515ff;
-}
-body button.r {
-    outline: 0;
-}
-
 body h1 {
     font-size: 10.42vh;
     text-align: center;
@@ -282,12 +249,6 @@ footer a {
     font-family: monospace;
     font-weight: 500;
     cursor: pointer;
-}
-
-body button.mini {
-    padding: 0.41vh 1.66vh;
-    font-size: 2.08vh;
-    line-height: -1.04vh;
 }
 
 h3 {


### PR DESCRIPTION
## Summary
- replace Material UI usage across pages with shadcn-inspired Tailwind components
- add reusable button, input, select, slider, switch, toggle group, and progress primitives
- update global styling to pull in Tailwind and drop legacy button styles while keeping existing layouts intact

## Testing
- bun install *(fails: registry access returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_68daadaa93308333a266b7389bc234b6