### PR TITLE
Implement server-authoritative kart simulation

### DIFF
--- a/frontend/src/game/api/meshes/MysteryBox.ts
+++ b/frontend/src/game/api/meshes/MysteryBox.ts
@@ -5,7 +5,6 @@ import { Global } from "../../store/Global";
 import { MathUtils } from "three";
 
 
-import { CS } from "@shared/types/codes";
 import { LocalPlayer } from "../../player/LocalPlayer";
 import { makeAutoLOD } from "../autoLLD";
 export class MysteryBox extends PhysicsObject {
@@ -77,7 +76,7 @@ export class MysteryBox extends PhysicsObject {
                 this.mysteryVisible &&
                 event.body.id === LocalPlayer.getInstance().id
             ) {
-                Global.client.send(CS.TOUCH_MYSTERY, id);
+                // Mystery triggers are processed on the server.
             }
         });
         Global.world.addBody(this);

--- a/frontend/src/game/api/setup/world.ts
+++ b/frontend/src/game/api/setup/world.ts
@@ -1,6 +1,5 @@
 import * as CANNON from "cannon-es";
 import CannonDebugger from "cannon-es-debugger";
-import msgpack from "msgpack-lite";
 import * as THREE from "three";
 import {
     BlendShader,
@@ -269,30 +268,6 @@ function setupSocket(
         LocalPlayer.getInstance().items.setItem(itemIndex);
     })
 
-    Global.client.onMessage(CC.KEY_DOWN, (args: { pid: number; buffer: Buffer }) => {
-        const xplayer = Player.clients.get(args.pid);
-
-        const [key, ...data] = msgpack.decode(
-            new Uint8Array(args.buffer)
-        ) as number[];
-        if (data.length) {
-            const [x, y, z, rx, ry, rz, rw] = data;
-            xplayer?.position.set(x, y, z);
-            xplayer?.quaternion.set(rx, ry, rz, rw);
-        }
-        xplayer?.keyboard.keysDown.add(key);
-    });
-
-    Global.client.onMessage(CC.UPDATE_TRANSFORM, (buffer: Buffer) => {
-        const [pid, ...data] = msgpack.decode(
-            new Uint8Array(buffer)
-        ) as number[];
-        const xplayer = Player.clients.get(pid);
-        const [x, y, z, rx, ry, rz, rw] = data;
-        xplayer?.position.set(x, y, z);
-        xplayer?.quaternion.set(rx, ry, rz, rw);
-    });
-
     Global.client.onMessage(CC.FINISH_LINE, (pid: number) => {
         TrackerController.FINALS.push(pid);
     });
@@ -342,20 +317,6 @@ function setupSocket(
             }
         }
     );
-    Global.client.onMessage(CC.KEY_UP, (args: { pid: number; buffer: Buffer }) => {
-        const xplayer = Player.clients.get(args.pid);
-        const [key, ...data] = msgpack.decode(
-            new Uint8Array(args.buffer)
-        ) as number[];
-        if (data.length) {
-            const [x, y, z, rx, ry, rz, rw] = data;
-            xplayer?.position.set(x, y, z);
-            xplayer?.quaternion.set(rx, ry, rz, rw);
-        }
-        xplayer?.keyboard.keysUp.add(key);
-        xplayer?.keyboard.keysPressed.delete(key);
-    });
-
     $(client.state).players.onRemove(({ color }) => {
         OnlinePlayer.clients.get(color)?.disconnect();
 

--- a/frontend/src/game/controller/DriveController.ts
+++ b/frontend/src/game/controller/DriveController.ts
@@ -7,8 +7,6 @@ import { IKeyboardController } from "./IKeyboardController";
 import clamp from "../api/clamp";
 import { AudioController } from "./AudioController";
 import { Player } from "../player/Player";
-import msgpack from "msgpack-lite";
-import { CS } from "../store/codes";
 import { StartTimer } from "../player/StartTimer";
 const maxDistance = 1;
 export class DriveController {
@@ -111,24 +109,6 @@ export class DriveController {
             // Apply the alignment quaternion to the current quaternion
             body.quaternion = alignUpQuat.mult(body.quaternion);
         };
-
-        islocal &&
-            setInterval(() => {
-                if (rocketMode || shakeMode || body.velocity.isZero()) return;
-                Global.client.send(
-                    CS.UPDATE_TRANSFORM,
-                    msgpack.encode([
-                        body.pid,
-                        body.position.x,
-                        body.position.y,
-                        body.position.z,
-                        body.quaternion.x,
-                        body.quaternion.y,
-                        body.quaternion.z,
-                        body.quaternion.w,
-                    ])
-                );
-            }, 1000);
 
         const keyboardUpdate = () => {
             if (keyboard.isKeyDown(32) || keyboard.isKeyDown(-6)) {

--- a/frontend/src/game/controller/KeyboardController.ts
+++ b/frontend/src/game/controller/KeyboardController.ts
@@ -1,8 +1,5 @@
-import { LocalPlayer } from "../player/LocalPlayer";
 import { Global } from "../store/Global";
-import { CS } from "../store/codes";
 import { IKeyboardController } from "./IKeyboardController";
-import msgpack from "msgpack-lite";
 
 export class KeyboardController extends IKeyboardController {
     constructor(enableOnStart: boolean = true) {
@@ -71,19 +68,6 @@ export class KeyboardController extends IKeyboardController {
             return;
         this.keysDown.add(event.which);
 
-        const data = [event.which];
-        if ([87, 83, 68, 65].includes(event.which)) {
-            const local = LocalPlayer.getInstance();
-            data.push(local.position.x);
-            data.push(local.position.y);
-            data.push(local.position.z);
-            data.push(local.quaternion.x);
-            data.push(local.quaternion.y);
-            data.push(local.quaternion.z);
-            data.push(local.quaternion.w);
-        }
-
-        Global.client.send(CS.KEY_DOWN, msgpack.encode(data));
     }
 
     private onKeyUp(event: KeyboardEvent) {
@@ -91,19 +75,5 @@ export class KeyboardController extends IKeyboardController {
 
         this.keysPressed.delete(event.which);
         this.keysUp.add(event.which);
-
-        const data = [event.which];
-        if ([87, 83, 68, 65].includes(event.which)) {
-            const local = LocalPlayer.getInstance();
-            data.push(local.position.x);
-            data.push(local.position.y);
-            data.push(local.position.z);
-            data.push(local.quaternion.x);
-            data.push(local.quaternion.y);
-            data.push(local.quaternion.z);
-            data.push(local.quaternion.w);
-        }
-
-        Global.client.send(CS.KEY_UP, msgpack.encode([event.which]));
     }
 }

--- a/frontend/src/game/net/PredictionController.ts
+++ b/frontend/src/game/net/PredictionController.ts
@@ -1,0 +1,106 @@
+import { Body } from "cannon-es";
+import { Vector3, Quaternion } from "three";
+import { Global } from "../store/Global";
+import { InputPayload, StatePayload } from "@shared/types/payloads";
+import { KCS, KCC } from "../store/codes";
+import { IKeyboardController } from "../controller/IKeyboardController";
+import { Player } from "../player/Player";
+
+const TICK_RATE = 60;
+const BUFFER_SIZE = 2048;
+const POSITION_THRESHOLD = 0.15;
+const RECONCILE_BLEND = 0.35;
+
+export class PredictionController {
+    private currentTick = 0;
+    private inputBuffer: Array<InputPayload | null> = new Array(BUFFER_SIZE).fill(null);
+    private stateBuffer: Array<StatePayload | null> = new Array(BUFFER_SIZE).fill(null);
+    private latestServerState: StatePayload | null = null;
+    private body: Body | null = null;
+
+    constructor(private readonly pid: number, private readonly keyboard: IKeyboardController) {
+        Global.client.onMessage(KCC.STATE_BUFFER, (state: StatePayload) => {
+            if (state.pid === this.pid) {
+                this.latestServerState = state;
+                this.reconcile(state);
+                return;
+            }
+
+            const remote = Player.clients.get(state.pid);
+            if (remote) {
+                remote.position.set(state.position.x, state.position.y, state.position.z);
+                remote.quaternion.set(
+                    state.quaternion.x,
+                    state.quaternion.y,
+                    state.quaternion.z,
+                    state.quaternion.w,
+                );
+            }
+        });
+    }
+
+    update(body: Body) {
+        if (!this.body) {
+            this.body = body;
+        }
+
+        const input: InputPayload = {
+            tick: this.currentTick,
+            inputVector: { x: this.keyboard.horizontal, y: this.keyboard.vertical },
+        };
+
+        const snapshot: StatePayload = {
+            pid: this.pid,
+            tick: this.currentTick,
+            position: {
+                x: body.position.x,
+                y: body.position.y,
+                z: body.position.z,
+            },
+            quaternion: {
+                x: body.quaternion.x,
+                y: body.quaternion.y,
+                z: body.quaternion.z,
+                w: body.quaternion.w,
+            },
+        };
+
+        const index = this.currentTick % BUFFER_SIZE;
+        this.inputBuffer[index] = input;
+        this.stateBuffer[index] = snapshot;
+
+        Global.client.send(KCS.INPUT_BUFFER, input);
+        this.currentTick += 1;
+    }
+
+    private reconcile(server: StatePayload) {
+        if (!this.body) return;
+
+        const body = this.body;
+        const targetPos = new Vector3(server.position.x, server.position.y, server.position.z);
+        const currentPos = new Vector3(body.position.x, body.position.y, body.position.z);
+        const error = currentPos.distanceTo(targetPos);
+
+        if (error < POSITION_THRESHOLD) {
+            return;
+        }
+
+        const blended = currentPos.lerp(targetPos, RECONCILE_BLEND);
+        body.position.set(blended.x, blended.y, blended.z);
+
+        const currentQuat = new Quaternion(
+            body.quaternion.x,
+            body.quaternion.y,
+            body.quaternion.z,
+            body.quaternion.w,
+        );
+        const targetQuat = new Quaternion(
+            server.quaternion.x,
+            server.quaternion.y,
+            server.quaternion.z,
+            server.quaternion.w,
+        );
+        currentQuat.slerp(targetQuat, RECONCILE_BLEND);
+        body.quaternion.set(currentQuat.x, currentQuat.y, currentQuat.z, currentQuat.w);
+    }
+}

--- a/frontend/src/game/player/LocalPlayer.ts
+++ b/frontend/src/game/player/LocalPlayer.ts
@@ -2,9 +2,11 @@ import { Player } from "./Player";
 import { KeyboardController } from "../controller/KeyboardController";
 import { TrackerController } from "../controller/TrackerController";
 import { Global } from "../store/Global";
+import { PredictionController } from "../net/PredictionController";
 
 export class LocalPlayer extends Player {
     private static instance: LocalPlayer;
+    private net: PredictionController;
 
     static getInstance() {
         return this.instance;
@@ -12,7 +14,10 @@ export class LocalPlayer extends Player {
     constructor(id: number, name: string, color: number) {
         super(id, true, name, color, new KeyboardController());
         LocalPlayer.instance = this;
+        Global.localPlayer = this;
+        this.net = new PredictionController(this.pid, this.keyboard);
         Global.lateUpdates.push(() => {
+            this.net.update(this);
             TrackerController.update(id);
         });
     }

--- a/server/src/entities/PlayerEntity.ts
+++ b/server/src/entities/PlayerEntity.ts
@@ -1,13 +1,168 @@
-import { World } from "cannon-es";
-import { Scene, Vector2, Vector3 } from "three";
+import {
+    Body,
+    Cylinder,
+    Material,
+    Quaternion as CQuaternion,
+    Vec3,
+    World,
+} from "cannon-es";
+import { Mesh, Quaternion, Raycaster, Vector3 } from "three";
+import { InputPayload, StatePayload } from "@shared/types/payloads";
 
+const SERVER_TICK_RATE = 60;
+const BUFFER_SIZE = 2048;
 
 export class PlayerEntity {
-    constructor(private scene: Scene, private world: World) {
+    public readonly body: Body;
+    public pid!: number;
 
+    private inputBuffer: Array<InputPayload | null> = new Array(BUFFER_SIZE).fill(null);
+    private stateBuffer: Array<StatePayload | null> = new Array(BUFFER_SIZE).fill(null);
+
+    private tick = 0;
+    private readonly dt = 1 / SERVER_TICK_RATE;
+
+    private raycaster = new Raycaster();
+    private tmpVec = new Vector3();
+    private tmpQuat = new Quaternion();
+    private forward = new Vec3(0, 0, 1);
+    private isAdded = false;
+
+    constructor(
+        private readonly world: World,
+        private readonly roadMeshes: Mesh[],
+    ) {
+        const radius = 0.8 / 3;
+        this.body = new Body({
+            mass: 1,
+            material: new Material({ friction: 0, restitution: 0 }),
+            position: new Vec3(0, 1, 0),
+            collisionFilterGroup: 1,
+            collisionFilterMask: ~0,
+        });
+        this.body.addShape(new Cylinder(radius, radius, radius));
+        (this.body as any).isPlayer = true;
+    }
+
+    spawn(pid: number, position: Vector3, quaternion: { x: number; y: number; z: number; w: number }) {
+        this.pid = pid;
+        this.tick = 0;
+        this.setTransform(position, quaternion);
+        (this.body as any).pid = pid;
+        if (!this.isAdded) {
+            this.world.addBody(this.body);
+            this.isAdded = true;
+        }
     }
 
     dispose() {
+        if (this.isAdded) {
+            this.world.removeBody(this.body);
+            this.isAdded = false;
+        }
+    }
 
+    onInput(payload: InputPayload) {
+        this.inputBuffer[payload.tick % BUFFER_SIZE] = payload;
+    }
+
+    processInput(tick: number) {
+        const payload = this.inputBuffer[tick % BUFFER_SIZE];
+        const inputX = payload?.inputVector.x ?? 0;
+        const inputY = payload?.inputVector.y ?? 0;
+        const accel = 45;
+        const steer = 2.5;
+        const damping = 0.15;
+
+        this.forward.set(0, 0, 1);
+        this.body.quaternion.vmult(this.forward, this.forward);
+
+        const thrust = accel * inputY;
+        const force = new Vec3(this.forward.x * thrust, this.forward.y * thrust, this.forward.z * thrust);
+        this.body.force.vadd(force, this.body.force);
+
+        const yawDelta = steer * inputX * this.dt;
+        if (Math.abs(yawDelta) > 1e-6) {
+            const yawQuat = new CQuaternion();
+            yawQuat.setFromAxisAngle(new Vec3(0, 1, 0), yawDelta);
+            this.body.quaternion = yawQuat.mult(this.body.quaternion);
+        }
+
+        this.body.velocity.scale(1 - damping * this.dt, this.body.velocity);
+
+        this.alignToGround();
+    }
+
+    afterPhysicsStep() {
+        const state: StatePayload = {
+            pid: this.pid,
+            tick: this.tick,
+            position: {
+                x: this.body.position.x,
+                y: this.body.position.y,
+                z: this.body.position.z,
+            },
+            quaternion: {
+                x: this.body.quaternion.x,
+                y: this.body.quaternion.y,
+                z: this.body.quaternion.z,
+                w: this.body.quaternion.w,
+            },
+        };
+
+        this.stateBuffer[this.tick % BUFFER_SIZE] = state;
+        this.tick += 1;
+    }
+
+    getState(tick: number) {
+        return this.stateBuffer[tick % BUFFER_SIZE];
+    }
+
+    getTick() {
+        return this.tick;
+    }
+
+    setTransform(position: Vector3, quaternion: { x: number; y: number; z: number; w: number }) {
+        this.body.position.set(position.x, position.y, position.z);
+        this.body.quaternion.set(quaternion.x, quaternion.y, quaternion.z, quaternion.w);
+        this.body.velocity.set(0, 0, 0);
+        this.body.angularVelocity.set(0, 0, 0);
+    }
+
+    private alignToGround() {
+        const origin = this.tmpVec.set(
+            this.body.position.x,
+            this.body.position.y + 1,
+            this.body.position.z,
+        );
+        this.raycaster.set(origin, new Vector3(0, -1, 0));
+        const hits = this.raycaster.intersectObjects(this.roadMeshes, false);
+        if (hits.length === 0) {
+            return;
+        }
+
+        const hit = hits[0];
+        if (!hit.face) return;
+
+        const normal = hit.face.normal.clone().transformDirection(hit.object.matrixWorld).normalize();
+        const currentUp = new Vector3(0, 1, 0).applyQuaternion(
+            this.tmpQuat.set(
+                this.body.quaternion.x,
+                this.body.quaternion.y,
+                this.body.quaternion.z,
+                this.body.quaternion.w,
+            ),
+        );
+
+        const axis = new Vector3().crossVectors(currentUp, normal);
+        const angle = axis.length();
+        if (angle < 1e-3) {
+            return;
+        }
+
+        axis.normalize();
+        const correction = new Quaternion().setFromAxisAngle(axis, angle * 0.3);
+        const corrected = correction.multiply(this.tmpQuat);
+        this.body.quaternion.set(corrected.x, corrected.y, corrected.z, corrected.w);
     }
 }

--- a/server/src/rooms/KartRace.ts
+++ b/server/src/rooms/KartRace.ts
@@ -2,200 +2,204 @@ import { Room, Client, AuthContext, Delayed } from "@colyseus/core";
 import { KartRaceState, PlayerSchema } from "./schema/KartRaceState";
 import { roadUtils as RoadUtils } from "@/utils/roadUtils";
 import { KartScene } from "@/scenes/KartScene";
-import { CC, CS } from "@shared/types/codes";
-import { MathUtils } from "three";
+import { CC, CS, KCS, KCC } from "@shared/types/codes";
+import { MathUtils, Vector3 } from "three";
+import { InputPayload, StatePayload } from "@shared/types/payloads";
 
 export class KartRace extends Room<
-  KartRaceState,
-  { hasPassword: boolean; roomName: string }
+    KartRaceState,
+    { hasPassword: boolean; roomName: string }
 > {
-  maxClients = 16;
-  autoDispose = false;
-  state = new KartRaceState();
-  private roadUtils: ReturnType<typeof RoadUtils>;
-  private scene: KartScene;
-  private password: string;
-  private firstJoinTimer: Delayed;
+    maxClients = 16;
+    autoDispose = false;
+    state = new KartRaceState();
+    private roadUtils: ReturnType<typeof RoadUtils>;
+    private spawnGenerator: ReturnType<ReturnType<typeof RoadUtils>["positionsGenerator"]>;
+    private scene: KartScene;
+    private password: string;
+    private firstJoinTimer: Delayed;
 
-  onAuth(client: Client<any, any>, options: any, context: AuthContext) {
-    console.log(
-      "clients",
-      client.sessionId,
-      "attempts to join with options",
-      options
-    );
-    if (this.password.length > 0 && options.password !== this.password) {
-      client.leave(1);
-      return false;
+    private readonly serverTickRate = 60;
+    private readonly dt = 1 / this.serverTickRate;
+
+    onAuth(client: Client, options: any, _context: AuthContext) {
+        if (this.password.length > 0 && options.password !== this.password) {
+            client.leave(1);
+            return false;
+        }
+
+        return true;
     }
 
-    return true;
-  }
+    onCreate(options: { mapId: number; password: string; roomName: string }) {
+        this.firstJoinTimer = this.clock.setTimeout(() => {
+            this.autoDispose = true;
+            this.disconnect();
+        }, 60_000);
 
-  onCreate(options: { mapId: number; password: string; roomName: string }) {
-    console.log(
-      "room",
-      this.roomId,
-      "created:",
-      JSON.stringify(options, null, 4)
-    );
+        this.setMetadata({
+            hasPassword: options.password.length > 0,
+            roomName: options.roomName,
+        });
 
-    this.firstJoinTimer = this.clock.setTimeout(() => {
-      this.autoDispose = true;
-      this.disconnect(); // triggers dispose when empty
-    }, 60_000);
+        this.roadUtils = RoadUtils(options.mapId);
+        this.spawnGenerator = this.roadUtils.positionsGenerator();
 
-    this.setMetadata({
-      hasPassword: options.password.length > 0,
-      roomName: options.roomName,
-    });
-    this.roadUtils = RoadUtils(options.mapId);
+        this.state.mapId = options.mapId;
+        this.password = options.password;
+        this.roadUtils.mysteries(this.state.mysteries);
 
-    this.state.mapId = options.mapId;
-    this.password = options.password;
+        this.scene = new KartScene(
+            this.state.mapId,
+            this.state.mysteries,
+            (pid, mysteryIndex) => this.handleMysteryTouched(pid, mysteryIndex),
+            () => {}
+        );
 
-    this.onMessage(CS.READY, (client, ready) => {
-      const xplayer = this.state.players.get(client.sessionId);
-      xplayer.assign({ ready });
+        this.setSimulationInterval(() => {
+            this.scene.forEachPlayer((_sessionId, entity) => {
+                entity.processInput(entity.getTick());
+            });
 
-      console.log(
-        "CS.READY",
-        client.sessionId,
-        "from:",
-        xplayer.ready,
-        "to:",
-        !xplayer.ready
-      );
-      this.state.players.set(client.sessionId, xplayer.clone());
+            this.scene.step(this.dt);
 
-      if (
-        Array.from(this.state.players.values()).filter(
-          (player) => !player.ready
-        ).length === 0
-      ) {
-        this.onGameStart();
-        this.lock();
-      }
-    });
+            const states: StatePayload[] = [];
+            this.scene.forEachPlayer((_sessionId, entity) => {
+                const state = entity.getState(entity.getTick() - 1);
+                if (state) {
+                    states.push(state);
+                }
+            });
 
-    this.onMessage(CS.TOUCH_MYSTERY, (client, id: number) => {
-      const toggleMystery = (id: number, visible: boolean) => {
-        this.state.mysteries[id] = this.state.mysteries[id]
-          .assign({ visible })
-          .clone();
-      };
-      toggleMystery(id, false);
+            if (states.length === 0) return;
 
-      client.send(CC.MYSTERY_ITEM, MathUtils.randInt(0, 4));
+            for (const client of this.clients) {
+                for (const state of states) {
+                    client.send(KCC.STATE_BUFFER, state);
+                }
+            }
+        }, 1000 / this.serverTickRate);
 
-      setTimeout(() => {
-        toggleMystery(id, true);
-      }, 1000);
-    });
+        this.onMessage(CS.READY, (client, ready) => {
+            const player = this.state.players.get(client.sessionId);
+            player.assign({ ready });
+            this.state.players.set(client.sessionId, player.clone());
 
-    const getPID = (client: Client) =>
-      this.state.players.get(client.sessionId).color;
+            const allReady = Array.from(this.state.players.values()).every((p) => p.ready);
+            if (allReady) {
+                this.onGameStart();
+                this.lock();
+            }
+        });
 
-    this.onMessage(CS.KEY_DOWN, (client, buffer: Buffer) => {
-      this.clients.forEach(
-        (c) =>
-          c.sessionId !== client.sessionId &&
-          c.send(CC.KEY_DOWN, { pid: getPID(client), buffer })
-      );
-    });
+        this.onMessage(CS.APPLY_MYSTERY, (client, data: number[]) => {
+            this.clients.forEach((c) =>
+                c.send(CC.APPLY_MYSTERY, [this.state.players.get(client.sessionId).color, ...data])
+            );
+        });
 
-    this.onMessage(CS.KEY_UP, (client, buffer: Buffer) => {
-      this.clients.forEach(
-        (c) =>
-          c.sessionId !== client.sessionId &&
-          c.send(CC.KEY_UP, { pid: getPID(client), buffer })
-      );
-    });
+        this.onMessage(CS.FINISH_LINE, (client) => {
+            this.clients.forEach((c) =>
+                c.send(CC.FINISH_LINE, this.state.players.get(client.sessionId).color)
+            );
 
-    this.onMessage(CS.APPLY_MYSTERY, (client, data: number[]) => {
-      this.clients.forEach((c) =>
-        c.send(CC.APPLY_MYSTERY, [getPID(client), ...data])
-      );
-    });
+            const schema = this.state.players.get(client.sessionId);
+            this.state.players.set(
+                client.sessionId,
+                schema.assign({ finished: true }).clone()
+            );
 
-    this.onMessage(CS.UPDATE_TRANSFORM, (client, buffer: Buffer) => {
-      this.clients.forEach(
-        (c) =>
-          c.sessionId !== client.sessionId &&
-          c.send(CC.UPDATE_TRANSFORM, buffer)
-      );
-    });
+            const allFinished = Array.from(this.state.players.values()).every((v) => v.finished);
+            if (allFinished) {
+                this.clients.forEach((c) =>
+                    c.send(CC.SHOW_WINNERS, this.state.players.get(client.sessionId).color)
+                );
+            }
+        });
 
-    this.onMessage(CS.FINISH_LINE, (client) => {
-      this.clients.forEach((c) => c.send(CC.FINISH_LINE, getPID(client)));
-
-      this.state.players.set(client.sessionId, this.state.players.get(client.sessionId).assign({ finished: true }));
-
-      const allFinishes = Array.from(this.state.players.values()).map(
-        (v) => v.finished
-      );
-
-      const allFinished =
-        allFinishes.filter((v) => !v).length === 0;
-
-      if (allFinished) {
-        this.clients.forEach((c) => c.send(CC.SHOW_WINNERS, getPID(client)));
-      }
-    });
-  }
-
-  onGameStart() {
-    this.state.startTime = Date.now() + 5_000;
-
-    this.scene = new KartScene(
-      this.state.mapId,
-      this.state.mysteries,
-      this.state.players
-    );
-
-    const generator = this.roadUtils.positionsGenerator();
-    this.state.players.forEach((player, key) => {
-      this.state.players.set(
-        key,
-        player.assign({ startTransform: generator() }).clone()
-      );
-    });
-
-    this.clock.setTimeout(() => {
-      this.clients.forEach((client) => client.send(CC.START_GAME));
-    }, this.patchRate * 3);
-  }
-
-  onJoin(client: Client, options: { playerName: string }) {
-    console.log(client.sessionId, "joined!");
-    this.state.players.set(
-      client.sessionId,
-      new PlayerSchema().assign({
-        ready: false,
-        name: options.playerName,
-        color: this.state.players.size,
-        id: client.sessionId,
-        finished: false,
-      })
-    );
-
-    this.firstJoinTimer.clear();
-    this.autoDispose = true;
-  }
-
-  onLeave(client: Client, consented: boolean) {
-    console.log(client.sessionId, "left!");
-    this.state.players.delete(client.sessionId);
-
-    this.scene?.onLeave(client.sessionId);
-
-    if (this.state.players.size === 0) {
-      this.disconnect();
+        this.onMessage(KCS.INPUT_BUFFER, (client, payload: InputPayload) => {
+            this.scene.onInput(client.sessionId, payload);
+        });
     }
-  }
 
-  onDispose() {
-    console.log("room", this.roomId, "disposing...");
-    this.scene?.dispose();
-  }
+    onGameStart() {
+        this.state.startTime = Date.now() + 5_000;
+
+        const generator = this.roadUtils.positionsGenerator();
+        this.spawnGenerator = this.roadUtils.positionsGenerator();
+        this.state.players.forEach((player, key) => {
+            const transform = generator();
+            this.state.players.set(key, player.assign({ startTransform: transform }).clone());
+
+            const entity = this.scene.getPlayer(key);
+            if (entity) {
+                const pos = transform.position;
+                const quat = transform.quaternion;
+                entity.setTransform(new Vector3(pos.x, pos.y, pos.z), {
+                    x: quat.x,
+                    y: quat.y,
+                    z: quat.z,
+                    w: quat.w,
+                });
+            }
+        });
+
+        this.clock.setTimeout(() => {
+            this.clients.forEach((client) => client.send(CC.START_GAME));
+        }, this.patchRate * 3);
+    }
+
+    onJoin(client: Client, options: { playerName: string }) {
+        const startTransform = this.spawnGenerator();
+        const player = new PlayerSchema().assign({
+            ready: false,
+            name: options.playerName,
+            color: this.state.players.size,
+            id: client.sessionId,
+            finished: false,
+            startTransform,
+        }).clone();
+
+        this.state.players.set(client.sessionId, player);
+
+        const pos = startTransform.position;
+        const quat = startTransform.quaternion;
+        this.scene.addPlayer(
+            client.sessionId,
+            player.color,
+            new Vector3(pos.x, pos.y, pos.z),
+            { x: quat.x, y: quat.y, z: quat.z, w: quat.w }
+        );
+
+        this.firstJoinTimer.clear();
+        this.autoDispose = true;
+    }
+
+    onLeave(client: Client) {
+        this.state.players.delete(client.sessionId);
+        this.scene.removePlayer(client.sessionId);
+
+        if (this.state.players.size === 0) {
+            this.disconnect();
+        }
+    }
+
+    onDispose() {
+        this.scene.dispose();
+    }
+
+    private handleMysteryTouched(pid: number, id: number) {
+        const toggleMystery = (index: number, visible: boolean) => {
+            this.state.mysteries[index] = this.state.mysteries[index].assign({ visible }).clone();
+        };
+
+        toggleMystery(id, false);
+
+        const client = this.clients.find(
+            (c) => this.state.players.get(c.sessionId)?.color === pid
+        );
+        client?.send(CC.MYSTERY_ITEM, MathUtils.randInt(0, 4));
+
+        this.clock.setTimeout(() => toggleMystery(id, true), 1000);
+    }
 }

--- a/server/src/scenes/KartScene.ts
+++ b/server/src/scenes/KartScene.ts
@@ -1,40 +1,181 @@
-import { MysteryBoxSchema, PlayerSchema } from "@/rooms/schema/KartRaceState";
-import { World } from "cannon-es";
-import { Scene } from "three";
-import { ArraySchema, MapSchema } from "@colyseus/schema";
-import { roadUtils } from "@/utils/roadUtils";
+import { ArraySchema } from "@colyseus/schema";
+import { Body, Box, Material, Vec3, World } from "cannon-es";
+import {
+    BufferGeometry,
+    CatmullRomCurve3,
+    Float32BufferAttribute,
+    Mesh,
+    MeshBasicMaterial,
+    Raycaster,
+    Scene,
+    Vector3,
+} from "three";
+import { MysteryBoxSchema } from "@/rooms/schema/KartRaceState";
 import { PlayerEntity } from "@/entities/PlayerEntity";
+import { curvePoints } from "@shared/config/road";
+import { InputPayload } from "@shared/types/payloads";
+
+type PlayerMap = Map<string, PlayerEntity>;
 
 export class KartScene {
-    private scene: Scene;
-    private world: World;
-    private players: Map<string, PlayerEntity>;
+    public readonly scene: Scene;
+    public readonly world: World;
 
-    constructor(mapId: number, mysteries: ArraySchema<MysteryBoxSchema>, playersSchema: MapSchema<PlayerSchema>) {
-        const road = roadUtils(mapId);
-        road.mysteries(mysteries);
+    private roadMeshes: Mesh[] = [];
+    private mysteryBodies: Body[] = [];
+    private players: PlayerMap = new Map();
 
+    constructor(
+        private mapId: number,
+        mysteries: ArraySchema<MysteryBoxSchema>,
+        private onMysteryTouched: (pid: number, mysteryIndex: number) => void,
+        private onPlayerStateStepped: (pid: number) => void,
+    ) {
         this.scene = new Scene();
-        this.world = new World()
+        this.world = new World();
+        this.world.gravity.set(0, 0, 0);
+        this.world.allowSleep = true;
 
-        this.players = new Map();
-        for (const key of playersSchema.keys()) {
-            this.players.set(key, new PlayerEntity(this.scene, this.world));
+        this.buildRoadGeometry();
+        this.buildMysteryTriggers(mysteries);
+
+        this.world.addEventListener("beginContact", (event: any) => {
+            const a = event.bodyA as Body;
+            const b = event.bodyB as Body;
+            const mystery = (a as any).isMystery ? a : (b as any).isMystery ? b : null;
+            const player = (a as any).isPlayer ? a : (b as any).isPlayer ? b : null;
+            if (!mystery || !player) return;
+
+            const mysteryIndex: number = (mystery as any).mysteryIndex;
+            const pid: number = (player as any).pid;
+            this.onMysteryTouched?.(pid, mysteryIndex);
+        });
+    }
+
+    addPlayer(
+        sessionId: string,
+        pid: number,
+        startPos: Vector3,
+        startQuat: { x: number; y: number; z: number; w: number },
+    ) {
+        const entity = new PlayerEntity(this.world, this.roadMeshes);
+        entity.spawn(pid, startPos, {
+            x: startQuat.x,
+            y: startQuat.y,
+            z: startQuat.z,
+            w: startQuat.w,
+        });
+        this.players.set(sessionId, entity);
+    }
+
+    removePlayer(sessionId: string) {
+        const entity = this.players.get(sessionId);
+        if (!entity) return;
+
+        entity.dispose();
+        this.players.delete(sessionId);
+    }
+
+    onInput(sessionId: string, payload: InputPayload) {
+        this.players.get(sessionId)?.onInput(payload);
+    }
+
+    step(dt: number) {
+        this.world.step(dt);
+
+        for (const [, entity] of this.players) {
+            entity.afterPhysicsStep();
+            this.onPlayerStateStepped?.(entity.pid);
         }
     }
 
-    update() {
-        this.world.step(1 / 60);
-    }
-
-    onLeave(id: string) {
-        const playerEntity = this.players.get(id);
-        playerEntity.dispose();
-
-        this.players.delete(id);
-    }
-
     dispose() {
+        this.roadMeshes.length = 0;
+        this.mysteryBodies.length = 0;
         this.scene.clear();
     }
+
+    private buildRoadGeometry() {
+        this.roadMeshes = createServerRoadMeshes(this.mapId);
+        for (const mesh of this.roadMeshes) {
+            this.scene.add(mesh);
+            mesh.updateMatrixWorld(true);
+        }
+    }
+
+    private buildMysteryTriggers(mysteries: ArraySchema<MysteryBoxSchema>) {
+        for (let i = 0; i < mysteries.length; i++) {
+            const mystery = mysteries[i];
+            const body = new Body({
+                mass: 0,
+                material: new Material({ friction: 0, restitution: 0 }),
+                position: new Vec3(mystery.position.x, mystery.position.y, mystery.position.z),
+                collisionFilterGroup: 3,
+                collisionFilterMask: 1,
+            });
+            body.addShape(new Box(new Vec3(0.25, 0.25, 0.25)));
+            (body as any).isMystery = true;
+            (body as any).mysteryIndex = mystery.index;
+            body.type = Body.KINEMATIC;
+            this.world.addBody(body);
+            this.mysteryBodies.push(body);
+        }
+    }
+
+    getPlayer(sessionId: string) {
+        return this.players.get(sessionId);
+    }
+
+    forEachPlayer(callback: (sessionId: string, entity: PlayerEntity) => void) {
+        for (const [id, entity] of this.players) {
+            callback(id, entity);
+        }
+    }
+}
+
+function createServerRoadMeshes(mapId: number): Mesh[] {
+    const points = curvePoints[mapId] ?? curvePoints[0];
+    const vectors: Vector3[] = [];
+    for (let i = 0; i < points.length; i += 3) {
+        vectors.push(new Vector3(points[i], points[i + 1], points[i + 2]));
+    }
+
+    const curve = new CatmullRomCurve3(vectors);
+    const segments = 1000;
+    const width = 7;
+
+    const positions: number[] = [];
+    const indices: number[] = [];
+
+    const forward = new Vector3();
+    const up = new Vector3(0, 1, 0);
+    const left = new Vector3();
+    const right = new Vector3();
+
+    const curvePointsArray = curve.getPoints(segments);
+    for (let i = 0; i < segments; i++) {
+        const p0 = curvePointsArray[i];
+        const p1 = curvePointsArray[i + 1] ?? curvePointsArray[i];
+
+        forward.copy(p1).sub(p0).normalize();
+        left.copy(up).cross(forward).normalize().multiplyScalar(width * 0.5);
+        right.copy(left).multiplyScalar(-1);
+
+        const a = new Vector3().copy(p0).add(left);
+        const b = new Vector3().copy(p0).add(right);
+        const c = new Vector3().copy(p1).add(right);
+        const d = new Vector3().copy(p1).add(left);
+
+        const base = positions.length / 3;
+        positions.push(a.x, a.y, a.z, b.x, b.y, b.z, c.x, c.y, c.z, d.x, d.y, d.z);
+        indices.push(base, base + 1, base + 2, base, base + 2, base + 3);
+    }
+
+    const geometry = new BufferGeometry();
+    geometry.setAttribute("position", new Float32BufferAttribute(positions, 3));
+    geometry.setIndex(indices);
+    geometry.computeVertexNormals();
+
+    const mesh = new Mesh(geometry, new MeshBasicMaterial());
+    return [mesh];
 }

--- a/shared/types/codes.ts
+++ b/shared/types/codes.ts
@@ -28,3 +28,12 @@ export enum CC {
     UPDATE_TRANSFORM = "f",
     FINISH_LINE = "l",
 }
+
+// ===== Authoritative movement channel (numeric opcodes) =====
+export enum KCS {
+    INPUT_BUFFER = 0,
+}
+
+export enum KCC {
+    STATE_BUFFER = 0,
+}

--- a/shared/types/payloads.ts
+++ b/shared/types/payloads.ts
@@ -1,0 +1,19 @@
+export type Vec2 = { x: number; y: number };
+export type Vec3 = { x: number; y: number; z: number };
+export type Quat = { x: number; y: number; z: number; w: number };
+
+export type InputPayload = {
+  tick: number;
+  inputVector: Vec2;
+  drift?: boolean;
+  turbo?: boolean;
+  item?: boolean;
+};
+
+export type StatePayload = {
+  pid: number;
+  tick: number;
+  position: Vec3;
+  quaternion: Quat;
+  velocity?: Vec3;
+};


### PR DESCRIPTION
## Summary
- add shared payload types and numeric opcodes for authoritative movement messages【F:shared/types/payloads.ts†L1-L19】【F:shared/types/codes.ts†L32-L39】
- build a server-side KartScene and PlayerEntity that simulate physics, drive mystery triggers, and broadcast authoritative states via KartRace【F:server/src/scenes/KartScene.ts†L20-L181】【F:server/src/entities/PlayerEntity.ts†L15-L167】【F:server/src/rooms/KartRace.ts†L9-L205】
- wire up a client prediction controller, remove legacy transform/keyboard relays, and keep mystery boxes client-visual only while the server handles triggers【F:frontend/src/game/net/PredictionController.ts†L1-L106】【F:frontend/src/game/player/LocalPlayer.ts†L1-L22】【F:frontend/src/game/controller/KeyboardController.ts†L1-L78】【F:frontend/src/game/controller/DriveController.ts†L1-L200】【F:frontend/src/game/api/meshes/MysteryBox.ts†L1-L82】

## Testing
- `npm run build` (server)【90151d†L1-L6】
- `npm run lint` (frontend) *(fails: next CLI not available in environment)*【2339df†L1-L8】

------
https://chatgpt.com/codex/tasks/task_e_68daba03a90083338922e31a071d402d